### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/Syntaxes/fancy.tmLanguage
+++ b/Syntaxes/fancy.tmLanguage
@@ -417,7 +417,7 @@
     </dict>
     <dict>
       <key>match</key>
-      <string>\b(0[xX]\h(?&gt;_?\h)*|\d(?&gt;_?\d)*(\.(?![^[:space:][:digit:]])(?&gt;_?\d)*)?([eE][-+]?\d(?&gt;_?\d)*)?|0[bB][01]+)\b</string>
+      <string>\b(0[xX][0-9A-Fa-f](?&gt;_?[0-9A-Fa-f])*|\d(?&gt;_?\d)*(\.(?![^[:space:][:digit:]])(?&gt;_?\d)*)?([eE][-+]?\d(?&gt;_?\d)*)?|0[bB][01]+)\b</string>
       <key>name</key>
       <string>constant.numeric.fancy</string>
     </dict>


### PR DESCRIPTION
Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Atom uses an Oniguruma engine, but github.com relies on a PCRE
engine.